### PR TITLE
Catch 40x errors which may not have "errors" in response body.

### DIFF
--- a/src/gardena/smart_system.py
+++ b/src/gardena/smart_system.py
@@ -140,9 +140,21 @@ class SmartSystem:
     def __response_has_errors(self, response):
         if response.status_code not in (200, 202):
             r = response.json()
-            self.logger.error(
-                f"{response.status_code} : {r['errors'][0]['title']} - {r['errors'][0]['detail']}"
-            )
+            if 'errors' in r:
+                msg = "{r['errors'][0]['title']} - {r['errors'][0]['detail']}"
+            elif 'message' in r:
+                msg = f"{r['message']}"
+
+                if response.status_code == 403:
+                    msg = f"{msg} (hint: did you 'Connect an API' in your Application?)"
+            else:
+                msg = f"{r}"
+
+            self.logger.error(f"{response.status_code} : {msg}")
+
+            if response.status_code in (401,403):
+                raise Exception(msg)
+
             return True
         return False
 


### PR DESCRIPTION
Hi, thanks for this API impl, just what I need for my new mower! :)

This occured when trying to use the Location API without having the GARDENA Smart System API connected in API console:
```
DEBUG:urllib3.connectionpool:https://api.smart.gardena.dev:443 "GET /v1/locations HTTP/1.1" 403 23
Traceback (most recent call last):
  File "test.py", line 9, in <module>
    smart_system.update_locations()
  File "/usr/home/johan/dev/gardena/py-smart-gardena/src/gardena/smart_system.py", line 156, in update_locations
    response_data = self.__call_smart_system_get(f"{self.SMART_HOST}/v1/locations")
  File "/usr/home/johan/dev/gardena/py-smart-gardena/src/gardena/smart_system.py", line 151, in __call_smart_system_get
    if self.__response_has_errors(response):
  File "/usr/home/johan/dev/gardena/py-smart-gardena/src/gardena/smart_system.py", line 144, in __response_has_errors
    f"{response.status_code} : {r['errors'][0]['title']} - {r['errors'][0]['detail']}"
KeyError: 'errors'
```

The response only held a "message" field with the value "Forbidden". This patch ensures a more graceful recovery and detection of this case.
It also throws an exception instead of just silently logging such hard errors.. If that is good or bad could of course be subject for discussion!